### PR TITLE
fix: preferred room capacity starts from 0

### DIFF
--- a/client/src/pages/Home/index.tsx
+++ b/client/src/pages/Home/index.tsx
@@ -618,7 +618,7 @@ const SettingsView = () => {
         ...formData,
         floor: floor || floors[0],
         duration: duration || commonDurations[0],
-        seats: Number(seats),
+        seats: Number(seats) || 1,
       });
     };
 


### PR DESCRIPTION
This PR solves a minor bug in  #59 PR where room capacity in settings starts from 0 since the cache was empty.